### PR TITLE
Fixed small bug in tagliatelleTagEditor controller

### DIFF
--- a/jezzipin.TagliatelleTagManager/jezzipin.TagliatelleTagManager/App_Plugins/Tagliatelle/PropertyEditors/tagliatelleTagEditor.controller.js
+++ b/jezzipin.TagliatelleTagManager/jezzipin.TagliatelleTagManager/App_Plugins/Tagliatelle/PropertyEditors/tagliatelleTagEditor.controller.js
@@ -40,7 +40,7 @@
 
 		// Toggle the display of existing website tags
     	$scope.showTags = function (e) {
-    		$('#tagliatelleTags').toggleClass('hide');
+    		 $(e.currentTarget.nextElementSibling).toggleClass('hide');
     	};
 
 		// Add a tag when the user presses enter


### PR DESCRIPTION
Bug: when using multiple tag datatypes in one documenttype we where unable to show/hide tags individuality.
Fix: toggleClass function gets run on current target > next element sibling